### PR TITLE
Add RPM build SPEC file

### DIFF
--- a/bash_completion/psn.bash
+++ b/bash_completion/psn.bash
@@ -1,0 +1,38 @@
+#============================================================================
+# Title       : psn.bash
+# Description : bash_completion file for process snapper
+# Author      : Bart Sjerps <bart@outrun.nl>
+# Usage       : Copy this file to /etc/bash_completion.d/
+# License     : GPLv3+
+# ---------------------------------------------------------------------------
+
+_psn() {
+  local -a opts shortopts longopts
+  local cur prev disks
+  _get_comp_words_by_ref cur prev
+
+  shortopts=(h d p t r a o i s g G)
+  longopts+=(pid thread recursive all-states sample-hz ps-hz output-sample-db input-sample-db list)
+  
+  opts=$(printf "\x2d%s " "${shortopts[@]}")
+  opts+=$(printf "\x2d\x2d%s " "${longopts[@]}")
+
+  case ${prev} in
+    psn)                   COMPREPLY=($(compgen -W "$opts" -- ${cur})) ;;
+    -h)                    ;;
+    -d)                    COMPREPLY=($(compgen -W "2 5 10" -- ${cur})) ;;
+    -p|--pid)              COMPREPLY=($(compgen -W "$(ps -eo comm)" -- ${cur})) ;;
+    -t)                    ;;
+    --list)                ;;
+    -r|--recursive)        COMPREPLY=($(compgen -W "$opts" -- ${cur})) ;;
+    -a|--all-states)       COMPREPLY=($(compgen -W "$opts" -- ${cur})) ;;
+       --sample-hz)        ;;
+       --ps-hz)            ;;
+    -o|--output-sample-db) COMPREPLY=($(compgen -f -- ${cur})) ;;
+    -i|--input-sample-db)  COMPREPLY=($(compgen -f -- ${cur})) ;;
+    -s|-g|-G)              COMPREPLY=($(compgen -W "$(psn --list | awk 'NF==2 {print $1}')" -- ${cur})) ;;
+    *)                     COMPREPLY=($(compgen -W "$opts" -- ${cur})) ;;
+  esac
+  return 0
+}
+complete -F _psn psn

--- a/bin/psn
+++ b/bin/psn
@@ -1,0 +1,3 @@
+#!/bin/bash
+# psnapper wrapper script, so we can call psn from anywhere without putting additional files in $PATH
+exec /usr/lib/psnapper/psn "$@"

--- a/man1/psn.1
+++ b/man1/psn.1
@@ -1,0 +1,124 @@
+.TH psn 1 "2019-05-01" "PSN" "Process Snapper User Manual"
+.SH NAME
+psn \- Linux Process Snapper
+.SH SYNOPSIS
+.B psn [-h] [--list]
+.br
+.B psn [options]
+
+.SH DESCRIPTION
+Linux Process Snapper (pSnapper, psn) is a Linux `/proc` profiler that
+works by sampling Linux task states and other metrics 
+from `/proc/PID/task/TID` pseudofiles. pSnapper is a
+.I passive sampling profiler
+, it does not attach to your program to slow it down,
+nor alter your program execution path or signal handling 
+(like `strace` may inadvertently do).
+
+As pSnapper is just a python script reading /proc files, it does not
+require software installation, nor install any kernel modules. 
+pSnapper does not even require root access in most cases. The exception 
+is if you want to sample some “private” /proc files (like syscall,
+and kernel stack) of processes running under other users.
+
+.SH OPTIONS
+.TP
+.B \-h, --help 
+show this help message and exit
+.TP
+.B  --list
+list all available columns
+.TP
+.B \-d <seconds>
+number of seconds to sample for
+.TP
+.B -p [pid], --pid [pid]
+process id to sample (including all its threads), or
+process name regex, or omit for system-wide sampling
+.TP
+.B -t [tid], --thread [tid]
+thread/task id to sample (not implemented yet)
+.TP
+.B  -r, --recursive
+also sample and report for descendant processes
+.TP
+.B -a, --all-states
+display threads in all states, including idle ones
+.TP
+.B --sample-hz SAMPLE_HZ
+sample rate in Hz
+.TP
+.B --ps-hz PS_HZ
+sample rate of new processes in Hz
+.TP
+.B -o filename, --output-sample-db filename
+path of sqlite3 database to persist samples to,
+defaults to in-memory/transient
+.TP
+.B -i filename, --input-sample-db filename
+path of sqlite3 database to read samples from instead
+of actively sampling
+.TP
+.B  -s csv-columns, --select csv-columns
+additional columns to report
+.TP
+.B  -g csv-columns, --group-by csv-columns
+columns to aggregate by in reports
+.TP
+.B  -G csv-columns, --append-group-by csv-columns
+ default + additional columns to aggregate by in reports
+
+.P
+.SH EXAMPLE
+.TP 4
+psn -h
+get help
+.TP
+psn --list
+show all possible reporting columns
+.TP
+psn
+run pSnapper for 5 seconds, report task comm,state profile (default)
+.TP
+psn -d 10
+same as above, but for 10 seconds
+.TP
+psn -p 1234
+run pSnapper for PID 1234
+.TP
+psn -p 1234 -r
+run pSnapper for PID 1234 and its children
+.TP
+psn -p 1234 -a
+as above, but show all thread states (including idle, interruptible sleep)
+.TP
+psn -p "post|kwork"
+run psnapper on processes  matching regex "post|kwork"
+.TP
+sudo psn -g comm,state,syscall
+customize sampled /proc columns (syscall is "private", so need sudo if sampling all procs)
+.TP
+psn -g cmdline,state,syscall,wchan
+choose exact sampled /proc columns
+.TP
+psn -G syscall,wchan
+append sampled columns in addition to the default "comm,state"
+.TP
+psn -G kstack
+show kernel stack backtraces in addition to the default columns
+
+.SH KNOWN ISSUES
+None currently
+.SH SEE ALSO
+sqlite3(1), proc(5), python(1)
+
+.SH AUTHOR
+Written by Tanel Poder \fIhttps://blog.tanelpoder.com/psnapper/\fR
+.br
+If you have suggestions for improvements in this tool, please send them along via the above address.
+
+.SH COPYRIGHT
+Copyright © 2019 Tanel Poder,  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+.br
+This is free software: you are free to change and redistribute it.  There is NO WARRANTY, to the extent permitted by law.
+

--- a/psnapper.spec
+++ b/psnapper.spec
@@ -1,12 +1,15 @@
 Name:		psnapper
 Summary:	Linux Process Snapper
 Version:	0.14
-Release:	1%{?dtap}
+Release:	2%{?dtap}
 BuildArch:	noarch
 URL:		https://tp.dev/psnapper
-Source0:	%{name}-%{version}.zip
+Source0:	%{name}-%{version}.tbz2
 License:	Python
 Group:		Outrun/Extras
+
+# Prevent compiling .py files
+%define	__python	false
 
 # This package can be downloaded from the 'Outrun Extras' repo, i.e.:
 # yum install http://yum.outrun.nl/outrun-extras.rpm
@@ -14,15 +17,22 @@ Group:		Outrun/Extras
 # This also ensures you get new versions when you run 'yum update'.
 #
 # RPM building:
+# Clone the git repo:
+# git clone https://github.com/tanelpoder/psnapper.git
+# cd to top of repository
+# cd psnapper
+# Create source archive:
+# git ls-files -z | xargs -0 tar jcvf $(rpm --eval %_sourcedir)/psnapper-0.14.tbz2 --transform 's|^|psnapper/|'
+# Build the package:
+# rpmbuild -bb psnapper.spec
+
 # defining macro %dtap as .~devel%(date +"%m%d%H%M") automagically
 # appends .~devel<datestamp> to the release.
 # leave %dtap empty to build the prod version
 # Optionally change Group to something else like System/Tools
-# Download ZIP file using this command:
-# wget https://github.com/tanelpoder/psnapper/archive/master.zip -O $(rpm --eval %_sourcedir)/psnapper-0.14.zip
 #
 # psnapper written by Tanel Poder
-# RPM Build SPEC file written by Bart Sjerps (bart@outrun.nl).
+# RPM Build SPEC, man page and bash completion file written by Bart Sjerps (bart@outrun.nl).
 
 %description
 Linux Process Snapper (pSnapper, psn) is a Linux '/proc' profiler that works by sampling
@@ -41,35 +51,34 @@ I have many more features to add, some known issues to fix
 and the output & command line options may change.
 
 %prep
-%setup -q -n psnapper-master
+%setup -q -n %{name}
 
 %install
 rm -rf %{buildroot}
-
+install -m 0755 -d %{buildroot}/etc/bash_completion.d
+install -m 0755 -d %{buildroot}/usr/bin
+install -m 0755 -d %{buildroot}/usr/share/man/man1
 install -m 0755 -d %{buildroot}/usr/share/doc/%{name}
 install -m 0755 -d %{buildroot}/usr/lib/%{name}
-install -m 0755 -d %{buildroot}/usr/bin
 
-install -m 0755 -pt %{buildroot}/usr/lib/%{name}/ *.py *.h psn
-install -m 0755 -pt %{buildroot}/usr/share/doc/%{name}/ CHANGELOG.md doc/licenses/Python-license.txt README.md
+cp -p bin/psn %{buildroot}/usr/bin
+cp -p bash_completion/psn.bash %{buildroot}/etc/bash_completion.d/
+cp -p man1/* %{buildroot}/usr/share/man/man1/
+cp -p *.py *.h psn %{buildroot}/usr/lib/%{name}/
+cp -p CHANGELOG.md doc/licenses/Python-license.txt README.md %{buildroot}/usr/share/doc/%{name}/
 
-# empty files to please %ghost section
+# empty files to please %ghost section (we don't want precompiled)
 touch %{buildroot}//usr/lib/%{name}/{report,proc,argparse}.pyc
 touch %{buildroot}//usr/lib/%{name}/{report,proc,argparse}.pyo
 
-# wrapper script so we can call psn from anywhere
-cat <<- 'EOF' > %{buildroot}/usr/bin/psn
-	#!/bin/bash
-	exec /usr/lib/%{name}/psn "$@"
-	EOF
-
-# Exit here prevents building and packaging *.pyc and *.pyo files
-# We want them as ghost files so they are not distro dependent
-exit 0
-
 %files
+%defattr(0644,root,root)
+/etc/bash_completion.d/psn.bash
 /usr/share/doc/%{name}
-/usr/lib/%{name}
+/usr/share/man/man1/*
+/usr/lib/%{name}/*.py
+/usr/lib/%{name}/*.h
+/usr/lib/%{name}/psn
 %ghost /usr/lib/%{name}/*.pyc
 %ghost /usr/lib/%{name}/*.pyo
 %defattr(0755,root,root)

--- a/psnapper.spec
+++ b/psnapper.spec
@@ -1,0 +1,76 @@
+Name:		psnapper
+Summary:	Linux Process Snapper
+Version:	0.14
+Release:	1%{?dtap}
+BuildArch:	noarch
+URL:		https://tp.dev/psnapper
+Source0:	%{name}-%{version}.zip
+License:	Python
+Group:		Outrun/Extras
+
+# This package can be downloaded from the 'Outrun Extras' repo, i.e.:
+# yum install http://yum.outrun.nl/outrun-extras.rpm
+# yum install psnapper
+# This also ensures you get new versions when you run 'yum update'.
+#
+# RPM building:
+# defining macro %dtap as .~devel%(date +"%m%d%H%M") automagically
+# appends .~devel<datestamp> to the release.
+# leave %dtap empty to build the prod version
+# Optionally change Group to something else like System/Tools
+# Download ZIP file using this command:
+# wget https://github.com/tanelpoder/psnapper/archive/master.zip -O $(rpm --eval %_sourcedir)/psnapper-0.14.zip
+#
+# psnapper written by Tanel Poder
+# RPM Build SPEC file written by Bart Sjerps (bart@outrun.nl).
+
+%description
+Linux Process Snapper (pSnapper, psn) is a Linux '/proc' profiler that works by sampling
+Linux task states and other metrics from '/proc/PID/task/TID' pseudofiles.
+pSnapper is a passive sampling profiler, it does not attach to your program
+to slow it down, nor alter your program execution path or signal
+handling (like 'strace' may inadvertently do).
+
+As pSnapper is just a python script reading /proc files, it does not require software
+installation, nor install any kernel modules. pSnapper does not even require root
+access in most cases. The exception is if you want to sample some "private" /proc
+files (like syscall, and kernel stack) of processes running under other users.
+
+The current, initial release version v0.11 is between alpha & beta stage.
+I have many more features to add, some known issues to fix
+and the output & command line options may change.
+
+%prep
+%setup -q -n psnapper-master
+
+%install
+rm -rf %{buildroot}
+
+install -m 0755 -d %{buildroot}/usr/share/doc/%{name}
+install -m 0755 -d %{buildroot}/usr/lib/%{name}
+install -m 0755 -d %{buildroot}/usr/bin
+
+install -m 0755 -pt %{buildroot}/usr/lib/%{name}/ *.py *.h psn
+install -m 0755 -pt %{buildroot}/usr/share/doc/%{name}/ CHANGELOG.md doc/licenses/Python-license.txt README.md
+
+# empty files to please %ghost section
+touch %{buildroot}//usr/lib/%{name}/{report,proc,argparse}.pyc
+touch %{buildroot}//usr/lib/%{name}/{report,proc,argparse}.pyo
+
+# wrapper script so we can call psn from anywhere
+cat <<- 'EOF' > %{buildroot}/usr/bin/psn
+	#!/bin/bash
+	exec /usr/lib/%{name}/psn "$@"
+	EOF
+
+# Exit here prevents building and packaging *.pyc and *.pyo files
+# We want them as ghost files so they are not distro dependent
+exit 0
+
+%files
+/usr/share/doc/%{name}
+/usr/lib/%{name}
+%ghost /usr/lib/%{name}/*.pyc
+%ghost /usr/lib/%{name}/*.pyo
+%defattr(0755,root,root)
+/usr/bin/psn

--- a/psnapper.spec
+++ b/psnapper.spec
@@ -76,10 +76,10 @@ touch %{buildroot}//usr/lib/%{name}/{report,proc,argparse}.pyo
 /etc/bash_completion.d/psn.bash
 /usr/share/doc/%{name}
 /usr/share/man/man1/*
-/usr/lib/%{name}/*.py
 /usr/lib/%{name}/*.h
-/usr/lib/%{name}/psn
 %ghost /usr/lib/%{name}/*.pyc
 %ghost /usr/lib/%{name}/*.pyo
 %defattr(0755,root,root)
+/usr/lib/%{name}/*.py
+/usr/lib/%{name}/psn
 /usr/bin/psn


### PR DESCRIPTION
SPEC file allows one to build an RPM package for EL6/7.

The package is available prebuilt from http://yum.outrun.nl/extras/x86_64/

Enjoy!