### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.pyc
 *.swp
-/bin/xcapture
+bin/xcapture

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CC=gcc
+PREFIX ?= /usr
 
 # build
 CFLAGS=-I include -Wall
@@ -19,16 +20,16 @@ debug0:
 	$(CC) $(CFLAGS_DEBUG0) -o bin/xcapture src/xcapture.c
 
 install:
-	# for now the temporary "install" method is with symlinks
-	ln -s `pwd`/bin/xcapture /usr/bin/xcapture
-	ln -s `pwd`/bin/psn /usr/bin/psn
-	ln -s `pwd`/bin/schedlat /usr/bin/schedlat
+	install -m 0755 bin/xcapture ${PREFIX}/bin/xcapture
+	install -m 0755 bin/psn ${PREFIX}/bin/psn
+	install -m 0755 bin/schedlat ${PREFIX}/bin/schedlat
+	install -m 0644 lib/proc.py ${PREFIX}/lib/proc.py
+	install -m 0644 lib/psnreport.py ${PREFIX}/lib/psnreport.py
+	install -m 0644 lib/argparse.py ${PREFIX}/lib/argparse.py
 
 uninstall:
-	rm -fv /usr/bin/xcapture
-	rm -fv /usr/bin/psn
-	rm -fv /usr/bin/schedlat
+	rm -fv ${PREFIX}/bin/xcapture ${PREFIX}/bin/psn ${PREFIX}/bin/schedlat
+	rm -fv ${PREFIX}/lib/proc.py ${PREFIX}/lib/psnreport.py ${PREFIX}/lib/argparse.py
 
 clean:
-	rm -f ./bin/xcapture
-
+	rm -f bin/xcapture

--- a/bin/psn
+++ b/bin/psn
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # use the following line on RHEL5 (if you have the additional python26 package installed from EPEL):
 ##!/usr/bin/env python26 


### PR DESCRIPTION
* Introduce PREFIX to Makefile so that we can do "make install PREFIX=/usr/local".
* And "uninstall" now works too, yeah :-D
* Install libraries from lib/ too, otherwise we run into another variant
  of #8 ("missing proc") again.
* While the default for "python" is Python3, "psn" needs Python2 and
  we need to change the shebang accordingly.
* no absolute path in .gitignore needed.