### PR TITLE
add few syscalls to report dir as filename

### DIFF
--- a/lib/0xtools/proc.py
+++ b/lib/0xtools/proc.py
@@ -353,6 +353,16 @@ syscalls_with_fd_arg = set([
   , syscall_name_to_id['getdents']        
   , syscall_name_to_id['getdents64']      
   , syscall_name_to_id['unlinkat']        
+  , syscall_name_to_id['fstat']
+  , syscall_name_to_id['fstatfs']
+  , syscall_name_to_id['newfstatat']
+  , syscall_name_to_id['openat']
+  , syscall_name_to_id['readv']
+  , syscall_name_to_id['writev']
+  , syscall_name_to_id['preadv']
+  , syscall_name_to_id['pwritev']
+  , syscall_name_to_id['preadv2']
+  , syscall_name_to_id['pwritev2']
 ])
 
 special_fds = { 0:'(stdin) ', 1:'(stdout)', 2:'(stderr)' }


### PR DESCRIPTION
getdents, unlinkat calls can be seen when working with directories with large number of files/inodes.
I'm not 100% sure it will work everywhere, and tested it on Ubuntu 20.04 only. It kinda works :)
```tiak@tiak-box:~/psn$ sudo ./psn -d 3 -G syscall,wchan,filename

Linux Process Snapper v0.18 by Tanel Poder [https://0x.tools]
Sampling /proc/syscall, wchan, stat for 3 seconds... finished.


=== Active Threads ======================================================================================================================

 samples | avg_threads | comm                   | state                  | syscall         | wchan                | filename             
-----------------------------------------------------------------------------------------------------------------------------------------
      17 |        0.53 | (rm)                   | Disk (Uninterruptible) | unlinkat        | jbd2_log_wait_commit | /home/tiak/psn-test  
      11 |        0.34 | (rm)                   | Disk (Uninterruptible) | unlinkat        | rq_qos_wait          | /home/tiak/psn-test  
       9 |        0.28 | (jbd*/dm-*-*)          | Disk (Uninterruptible) | [kernel_thread] | __wait_on_buffer     |                      
       7 |        0.22 | (jbd*/dm-*-*)          | Disk (Uninterruptible) | [kernel_thread] | rq_qos_wait          |                      
       3 |        0.09 | (llvmpipe-*)           | Running (ON CPU)       | [running]       | 0                    |                      
       3 |        0.09 | (rm)                   | Running (ON CPU)       | [running]       | 0                    |                      
       1 |        0.03 | (kworker/*:*H+kblockd) | Running (ON CPU)       | [running]       | 0                    |                      
       1 |        0.03 | (rcu_sched)            | Running (ON CPU)       | [running]       | 0                    |                      
       1 |        0.03 | (rm)                   | Disk (Uninterruptible) | unlinkat        | submit_bio_wait      | /home/tiak/psn-test  
```