### PR TITLE
Add unistd.h path of CentOS7 ppc64le release

### DIFF
--- a/lib/0xtools/proc.py
+++ b/lib/0xtools/proc.py
@@ -317,7 +317,7 @@ def extract_system_call_ids(unistd_64_fh):
 def get_system_call_names():
     psn_dir=os.path.dirname(os.path.realpath(__file__))
     kernel_ver=platform.release().split('-')[0]
-    unistd_64_paths = ['/usr/include/asm/unistd_64.h', '/usr/include/x86_64-linux-gnu/asm/unistd_64.h', '/usr/include/asm-x86_64/unistd.h', psn_dir+'/syscall_64_'+kernel_ver+'.h', psn_dir+'/syscall_64.h']
+    unistd_64_paths = ['/usr/include/asm/unistd_64.h', '/usr/include/x86_64-linux-gnu/asm/unistd_64.h', '/usr/include/asm-x86_64/unistd.h', '/usr/include/asm/unistd.h', psn_dir+'/syscall_64_'+kernel_ver+'.h', psn_dir+'/syscall_64.h']
     for path in unistd_64_paths:
         try:
             with open(path) as f:


### PR DESCRIPTION
psn tool can't run on centos 7.9 ppc64le release and will report
can't find unistd_x64.h file even after install kernel-headers.
After adding path of unistd.h to proc.py, psn tool works now.