### PR TITLE
Bugfix: ValueError: invalid literal for int() with base 10

### DIFF
--- a/bin/xcapture-bpf
+++ b/bin/xcapture-bpf
@@ -49,7 +49,7 @@ def extract_system_call_ids(unistd_64_fh):
     for name_prefix in ['__NR_', '__NR3264_']:
         for line in unistd_64_fh.readlines():
             tokens = line.split()
-            if tokens and len(tokens) == 3 and tokens[0] == '#define':
+	    if tokens and len(tokens) == 3 and tokens[0] == '#define' and tokens[2].isnumeric() is True:
                 _, s_name, s_id = tokens
                 s_id = int(s_id)
                 if s_name.startswith(name_prefix):

--- a/bin/xcapture-bpf.c
+++ b/bin/xcapture-bpf.c
@@ -70,7 +70,11 @@ struct thread_state_t {
 BPF_HASH(tsa, u32, struct thread_state_t, 16384);
 
 TRACEPOINT_PROBE(raw_syscalls, sys_enter) {
+#if defined(__x86_64__)
     if (args->id ==  __NR_poll || args->id == __NR_getrusage)
+#elif defined(__aarch64__)
+    if (args->id == __NR_getrusage)
+#endif
         return 0;
 
     struct thread_state_t t_empty = {};


### PR DESCRIPTION
On ARM64 the file "/usr/include/asm-generic/unistd.h" includes entries like "#define __SYSCALL(x, y)" which result in valueError - this additional check avoids it.