### PR TITLE
fix: use /proc/partitions instead of $data_dir/partitions

### DIFF
--- a/xtop/core/data_source.py
+++ b/xtop/core/data_source.py
@@ -254,12 +254,12 @@ class XCaptureDataSource:
         Read partitions file to map device numbers to names.
         Returns dict: {major:minor -> device_name}
         """
-        partitions_file = self.datadir / 'partitions'
+        partitions_file = Path('/proc/partitions')
         device_map = {}
-        
+
         if not partitions_file.exists():
             return device_map
-        
+
         try:
             with open(partitions_file, 'r') as f:
                 # Skip header line
@@ -273,7 +273,7 @@ class XCaptureDataSource:
                         device_map[f"{major}:{minor}"] = name
         except Exception:
             pass
-        
+
         return device_map
     
     def __enter__(self):

--- a/xtop/core/materializer.py
+++ b/xtop/core/materializer.py
@@ -140,7 +140,7 @@ class DataMaterializer:
                 SELECT
                     REGEXP_EXTRACT_ALL(column0, ' +(\\w+)') field_list
                 FROM
-                    read_csv('{self.datadir}/partitions', skip=1, header=false)
+                    read_csv('/proc/partitions', skip=1, header=false)
                 WHERE
                     field_list IS NOT NULL
             )

--- a/xtop/sql/fragments/base_partitions.sql
+++ b/xtop/sql/fragments/base_partitions.sql
@@ -8,7 +8,7 @@ FROM (
     SELECT
         REGEXP_EXTRACT_ALL(column0, ' +(\w+)') field_list
     FROM
-        read_csv('#XTOP_DATADIR#/partitions', skip=1, header=false)
+        read_csv('/proc/partitions', skip=1, header=false)
     WHERE
         field_list IS NOT NULL
 )

--- a/xtop/sql/fragments/get_partitions.sql
+++ b/xtop/sql/fragments/get_partitions.sql
@@ -9,7 +9,7 @@ LEFT OUTER JOIN (
         SELECT
             REGEXP_EXTRACT_ALL(column0, ' +(\w+)') field_list
         FROM
-            read_csv('#XTOP_DATADIR#/partitions', skip=1, header=false)
+            read_csv('/proc/partitions', skip=1, header=false)
         WHERE
             field_list IS NOT NULL
     )

--- a/xtop/tui/cell_peek_modal_old.py
+++ b/xtop/tui/cell_peek_modal_old.py
@@ -406,7 +406,7 @@ class HistogramPeekModal(CellPeekModal):
                 SELECT
                     REGEXP_EXTRACT_ALL(column0, ' +(\\w+)') field_list
                 FROM
-                    read_csv('{self.datadir}/partitions', skip=1, header=false)
+                    read_csv('/proc/partitions', skip=1, header=false)
                 WHERE
                     field_list IS NOT NULL
             )


### PR DESCRIPTION
It looks wrong xtop is looking for partitions file in `$data_dir/partitions`. I got this error when I try to group by devname which brings in the partitions source:

```
2025-11-25 17:56:52,253 - DEBUG - ================================================================================
2025-11-25 17:56:52,389 - ERROR - Query execution failed: IO Error: No files found that match the pattern "/var/lib/xcapture/partitions"

LINE 146:         read_csv('/var/lib/xcapture/partitions', skip=1, header...
                  ^
Traceback (most recent call last):
  File "/codemill/yeya/git/vendor/0xtools/xtop/./xtop", line 1182, in execute_current_query
    result = self.query_engine.execute_with_params(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/codemill/yeya/git/vendor/0xtools/xtop/core/query_engine.py", line 244, in execute_with_params
    return self.execute(query, params, debug, debug_profile)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/codemill/yeya/git/vendor/0xtools/xtop/core/query_engine.py", line 178, in execute
    result = conn.execute(query)
             ^^^^^^^^^^^^^^^^^^^
_duckdb.IOException: IO Error: No files found that match the pattern "/var/lib/xcapture/partitions"

LINE 146:         read_csv('/var/lib/xcapture/partitions', skip=1, header...
                  ^
2025-11-25 17:56:52,393 - INFO - samples: using csv for 1 hour(s)
```